### PR TITLE
Add parquet-to-JSON refresh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# table-hockey-app
+# Table Hockey Match Explorer
+
+This project is a static website (index.html, style.css, script.js) that lets you
+explore historical table hockey match data.
+
+## Refreshing `matches.json`
+
+The site expects a `matches.json` file that mirrors the schema of the original
+Parquet dataset hosted at:
+
+```
+https://raw.githubusercontent.com/amundfylling/Scorpion-Scraper-2.0/main/data/scraped_matches.parquet
+```
+
+Run the helper script to download the parquet file and convert it to JSON:
+
+```bash
+python convert_parquet_to_json.py
+```
+
+By default the script writes `matches.json` to the current directory. Use
+`--output` to change the destination or `--parquet-url` to target a different
+source file. This makes it easy to schedule a daily refresh with a cron job or a
+GitHub Actions workflow.

--- a/convert_parquet_to_json.py
+++ b/convert_parquet_to_json.py
@@ -1,0 +1,82 @@
+"""Utility script to refresh matches.json from the upstream parquet dataset.
+
+Usage
+-----
+python convert_parquet_to_json.py \
+    --parquet-url https://raw.githubusercontent.com/amundfylling/Scorpion-Scraper-2.0/main/data/scraped_matches.parquet \
+    --output matches.json
+
+By default the script uses the upstream parquet URL shown above and writes to
+`matches.json` in the current working directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+DEFAULT_PARQUET_URL = (
+    "https://raw.githubusercontent.com/amundfylling/Scorpion-Scraper-2.0/main/data/"
+    "scraped_matches.parquet"
+)
+DEFAULT_OUTPUT = "matches.json"
+
+
+def download_parquet(parquet_url: str) -> io.BytesIO:
+    """Download a parquet file and return its binary content as a BytesIO buffer."""
+    response = requests.get(parquet_url, timeout=60)
+    response.raise_for_status()
+    return io.BytesIO(response.content)
+
+
+def convert(parquet_url: str, output_path: Path) -> None:
+    """Convert the remote parquet data to newline-free JSON records."""
+    parquet_bytes = download_parquet(parquet_url)
+    df = pd.read_parquet(parquet_bytes)
+
+    # Replace pandas-specific NaN values with plain ``None`` so JSON stays clean.
+    df = df.where(pd.notnull(df), None)
+
+    records = df.to_dict(orient="records")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as json_file:
+        json.dump(records, json_file, ensure_ascii=False, indent=2)
+
+    print(
+        f"Wrote {len(records)} records to {output_path} "
+        f"(source: {parquet_url})"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download the upstream parquet dataset and export it as matches.json "
+            "for the static site."
+        )
+    )
+    parser.add_argument(
+        "--parquet-url",
+        default=DEFAULT_PARQUET_URL,
+        help="URL of the parquet file to download (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--output",
+        default=DEFAULT_OUTPUT,
+        help="Path to the JSON file that will be written (default: %(default)s)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    convert(args.parquet_url, Path(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/index.html
+++ b/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Table Hockey Match Explorer</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>Table Hockey Match Explorer</h1>
+            <p>Explore match results and player performance from table hockey tournaments.</p>
+        </div>
+    </header>
+
+    <main class="container">
+        <section class="controls">
+            <label for="playerSelect">Choose a player:</label>
+            <select id="playerSelect" disabled>
+                <option value="">Loading players...</option>
+            </select>
+            <p id="statusMessage" class="status">Fetching match data...</p>
+            <p id="errorMessage" class="error hidden"></p>
+        </section>
+
+        <section id="summarySection" class="summary hidden">
+            <h2>Player Summary</h2>
+            <div class="summary-grid">
+                <div class="stat-card">
+                    <span class="stat-label">Total Games</span>
+                    <span class="stat-value" id="totalGames">0</span>
+                </div>
+                <div class="stat-card">
+                    <span class="stat-label">Wins</span>
+                    <span class="stat-value" id="wins">0</span>
+                </div>
+                <div class="stat-card">
+                    <span class="stat-label">Losses</span>
+                    <span class="stat-value" id="losses">0</span>
+                </div>
+                <div class="stat-card">
+                    <span class="stat-label">Draws</span>
+                    <span class="stat-value" id="draws">0</span>
+                </div>
+                <div class="stat-card">
+                    <span class="stat-label">Goals Scored</span>
+                    <span class="stat-value" id="goalsFor">0</span>
+                </div>
+                <div class="stat-card">
+                    <span class="stat-label">Goals Conceded</span>
+                    <span class="stat-value" id="goalsAgainst">0</span>
+                </div>
+                <div class="stat-card">
+                    <span class="stat-label">Win Percentage</span>
+                    <span class="stat-value" id="winPercentage">0%</span>
+                </div>
+            </div>
+        </section>
+
+        <section id="matchesSection" class="table-section hidden">
+            <h2>Match History</h2>
+            <p id="noMatchesMessage" class="info hidden">No matches found for the selected player.</p>
+            <div class="table-wrapper">
+                <table id="matchesTable">
+                    <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>Opponent</th>
+                            <th>Player Goals</th>
+                            <th>Opponent Goals</th>
+                            <th>Result</th>
+                            <th>Tournament</th>
+                        </tr>
+                    </thead>
+                    <tbody id="matchesTableBody">
+                        <!-- Rows populated by script.js -->
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>Data sourced from the Scorpion Scraper project.</p>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,264 @@
+// script.js
+// -------------
+// This file is responsible for fetching the match data, populating the player dropdown,
+// and rendering summary statistics + match history for the selected player.
+
+// Wait for the DOM to be fully parsed before touching any elements.
+document.addEventListener('DOMContentLoaded', () => {
+    const playerSelect = document.getElementById('playerSelect');
+    const summarySection = document.getElementById('summarySection');
+    const matchesSection = document.getElementById('matchesSection');
+    const matchesTableBody = document.getElementById('matchesTableBody');
+    const statusMessage = document.getElementById('statusMessage');
+    const errorMessage = document.getElementById('errorMessage');
+    const noMatchesMessage = document.getElementById('noMatchesMessage');
+
+    // Cache references to each summary field so we can update them quickly.
+    const summaryFields = {
+        totalGames: document.getElementById('totalGames'),
+        wins: document.getElementById('wins'),
+        losses: document.getElementById('losses'),
+        draws: document.getElementById('draws'),
+        goalsFor: document.getElementById('goalsFor'),
+        goalsAgainst: document.getElementById('goalsAgainst'),
+        winPercentage: document.getElementById('winPercentage'),
+    };
+
+    let allMatches = [];
+
+    // Kick off the fetch as soon as the page loads.
+    loadMatches();
+
+    // Respond to player selection changes.
+    playerSelect.addEventListener('change', (event) => {
+        const selectedPlayer = event.target.value;
+
+        // If the user clears the selection, hide the data panels.
+        if (!selectedPlayer) {
+            summarySection.classList.add('hidden');
+            matchesSection.classList.add('hidden');
+            noMatchesMessage.classList.add('hidden');
+            clearTable();
+            statusMessage.textContent = 'Select a player to view match details.';
+            return;
+        }
+
+        const playerMatches = filterMatchesForPlayer(selectedPlayer);
+        statusMessage.textContent = `Viewing matches for ${selectedPlayer}.`;
+        updateSummary(playerMatches, selectedPlayer);
+        updateMatchTable(playerMatches, selectedPlayer);
+    });
+
+    /**
+     * Fetch the JSON dataset containing match records. The file is expected to be
+     * stored next to this script in the repository.
+     */
+    async function loadMatches() {
+        try {
+            const response = await fetch('matches.json', { cache: 'no-store' });
+
+            if (!response.ok) {
+                throw new Error(`Failed to fetch matches.json (status ${response.status})`);
+            }
+
+            const data = await response.json();
+
+            // The dataset should be an array. If it is nested in an object,
+            // fall back to the first array-like property we can find.
+            if (Array.isArray(data)) {
+                allMatches = data;
+            } else if (Array.isArray(data.matches)) {
+                allMatches = data.matches;
+            } else {
+                allMatches = [];
+                throw new Error('matches.json did not contain an array of match records.');
+            }
+
+            populatePlayerDropdown(allMatches);
+            statusMessage.textContent = 'Select a player to view match details.';
+            errorMessage.classList.add('hidden');
+            playerSelect.disabled = false;
+        } catch (error) {
+            console.error(error);
+            errorMessage.textContent = 'Unable to load match data. Please refresh the page to try again.';
+            errorMessage.classList.remove('hidden');
+            statusMessage.textContent = '';
+            playerSelect.disabled = true;
+        }
+    }
+
+    /**
+     * Extract all unique player names from the dataset and insert them into the select control.
+     */
+    function populatePlayerDropdown(matches) {
+        const playerNames = new Set();
+
+        matches.forEach((match) => {
+            if (match.Player1) playerNames.add(match.Player1);
+            if (match.Player2) playerNames.add(match.Player2);
+        });
+
+        const sortedNames = Array.from(playerNames).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+
+        // Reset the select menu before repopulating it.
+        playerSelect.innerHTML = '<option value="">Select a player</option>';
+
+        sortedNames.forEach((name) => {
+            const option = document.createElement('option');
+            option.value = name;
+            option.textContent = name;
+            playerSelect.appendChild(option);
+        });
+    }
+
+    /**
+     * Filter the match dataset down to the games that involve the selected player.
+     */
+    function filterMatchesForPlayer(playerName) {
+        return allMatches.filter((match) => match.Player1 === playerName || match.Player2 === playerName);
+    }
+
+    /**
+     * Compute and render summary statistics (wins, losses, goals, etc.).
+     */
+    function updateSummary(matches, playerName) {
+        if (!matches.length) {
+            summarySection.classList.add('hidden');
+            summaryFields.totalGames.textContent = '0';
+            summaryFields.wins.textContent = '0';
+            summaryFields.losses.textContent = '0';
+            summaryFields.draws.textContent = '0';
+            summaryFields.goalsFor.textContent = '0';
+            summaryFields.goalsAgainst.textContent = '0';
+            summaryFields.winPercentage.textContent = '0%';
+            return;
+        }
+
+        let wins = 0;
+        let draws = 0;
+        let goalsFor = 0;
+        let goalsAgainst = 0;
+
+        matches.forEach((match) => {
+            const { playerGoals, opponentGoals } = extractScore(match, playerName);
+
+            goalsFor += playerGoals;
+            goalsAgainst += opponentGoals;
+
+            if (playerGoals > opponentGoals) {
+                wins += 1;
+            } else if (playerGoals === opponentGoals) {
+                draws += 1;
+            }
+        });
+
+        const totalGames = matches.length;
+        const losses = totalGames - wins - draws;
+        const winPercentage = totalGames ? ((wins / totalGames) * 100).toFixed(1) : '0.0';
+
+        summaryFields.totalGames.textContent = totalGames.toString();
+        summaryFields.wins.textContent = wins.toString();
+        summaryFields.losses.textContent = losses.toString();
+        summaryFields.draws.textContent = draws.toString();
+        summaryFields.goalsFor.textContent = goalsFor.toString();
+        summaryFields.goalsAgainst.textContent = goalsAgainst.toString();
+        summaryFields.winPercentage.textContent = `${winPercentage}%`;
+
+        summarySection.classList.remove('hidden');
+    }
+
+    /**
+     * Build the match table for the selected player.
+     */
+    function updateMatchTable(matches, playerName) {
+        clearTable();
+
+        if (!matches.length) {
+            matchesSection.classList.remove('hidden');
+            noMatchesMessage.classList.remove('hidden');
+            return;
+        }
+
+        // Sort matches by date descending so the latest games appear first.
+        const sortedMatches = [...matches].sort((a, b) => {
+            const timeA = new Date(a.Date).getTime();
+            const timeB = new Date(b.Date).getTime();
+
+            if (Number.isNaN(timeA) || Number.isNaN(timeB)) {
+                return 0;
+            }
+
+            return timeB - timeA;
+        });
+
+        sortedMatches.forEach((match) => {
+            const { playerGoals, opponentGoals, opponentName } = extractScore(match, playerName);
+            const result = determineResult(playerGoals, opponentGoals);
+            const formattedDate = formatDate(match.Date);
+
+            const row = document.createElement('tr');
+
+            row.innerHTML = `
+                <td>${formattedDate}</td>
+                <td>${opponentName}</td>
+                <td>${playerGoals}</td>
+                <td>${opponentGoals}</td>
+                <td class="result-${result.toLowerCase()}">${result}</td>
+                <td>${match.TournamentName || 'Unknown Tournament'}</td>
+            `;
+
+            matchesTableBody.appendChild(row);
+        });
+
+        matchesSection.classList.remove('hidden');
+        noMatchesMessage.classList.add('hidden');
+    }
+
+    /**
+     * Empty the match table before repopulating it.
+     */
+    function clearTable() {
+        matchesTableBody.innerHTML = '';
+    }
+
+    /**
+     * Determine the goals scored by the selected player and their opponent.
+     */
+    function extractScore(match, playerName) {
+        const playerIsPlayer1 = match.Player1 === playerName;
+
+        const playerGoals = Number(playerIsPlayer1 ? match.GoalsPlayer1 : match.GoalsPlayer2) || 0;
+        const opponentGoals = Number(playerIsPlayer1 ? match.GoalsPlayer2 : match.GoalsPlayer1) || 0;
+        const opponentName = playerIsPlayer1 ? match.Player2 || 'Unknown Opponent' : match.Player1 || 'Unknown Opponent';
+
+        return { playerGoals, opponentGoals, opponentName };
+    }
+
+    /**
+     * Convert raw goal counts into a match result label.
+     */
+    function determineResult(playerGoals, opponentGoals) {
+        if (playerGoals > opponentGoals) return 'Win';
+        if (playerGoals < opponentGoals) return 'Loss';
+        return 'Draw';
+    }
+
+    /**
+     * Attempt to format a date string into a friendly format. If parsing fails,
+     * fall back to the original string.
+     */
+    function formatDate(dateString) {
+        if (!dateString) return 'Unknown';
+
+        const parsedDate = new Date(dateString);
+        if (Number.isNaN(parsedDate.getTime())) {
+            return dateString;
+        }
+
+        return parsedDate.toLocaleDateString(undefined, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+        });
+    }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,210 @@
+:root {
+    --background-color: #f4f6fb;
+    --card-background: #ffffff;
+    --primary-color: #1f3c88;
+    --accent-color: #ff6b35;
+    --text-color: #1f2933;
+    --muted-text: #52606d;
+    --border-color: #d9e2ec;
+    --shadow: 0 4px 12px rgba(31, 60, 136, 0.08);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background-color: var(--background-color);
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+header {
+    background: linear-gradient(135deg, var(--primary-color), #274690);
+    color: #ffffff;
+    padding: 2.5rem 0;
+    box-shadow: var(--shadow);
+}
+
+header h1 {
+    margin: 0 0 0.5rem;
+    font-size: 2rem;
+}
+
+header p {
+    margin: 0;
+    max-width: 720px;
+}
+
+.container {
+    width: min(1100px, 92%);
+    margin: 0 auto;
+}
+
+main {
+    padding: 2rem 0 3rem;
+}
+
+.controls {
+    background-color: var(--card-background);
+    padding: 1.5rem;
+    border-radius: 12px;
+    box-shadow: var(--shadow);
+    margin-bottom: 2rem;
+}
+
+.controls label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.controls select {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background-color: #ffffff;
+    font-size: 1rem;
+    color: var(--text-color);
+    transition: border-color 0.2s ease;
+}
+
+.controls select:focus {
+    outline: none;
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 3px rgba(255, 107, 53, 0.2);
+}
+
+.status,
+.error,
+.info {
+    margin-top: 0.75rem;
+    font-size: 0.95rem;
+}
+
+.status {
+    color: var(--muted-text);
+}
+
+.error {
+    color: #c81e1e;
+}
+
+.info {
+    color: var(--muted-text);
+}
+
+.summary {
+    margin-bottom: 2rem;
+}
+
+.summary h2,
+.table-section h2 {
+    margin-top: 0;
+}
+
+.summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+}
+
+.stat-card {
+    background-color: var(--card-background);
+    border-radius: 12px;
+    padding: 1.25rem;
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.stat-label {
+    font-size: 0.9rem;
+    color: var(--muted-text);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.stat-value {
+    font-size: 1.6rem;
+    font-weight: 600;
+    color: var(--primary-color);
+}
+
+.table-section {
+    background-color: var(--card-background);
+    border-radius: 12px;
+    box-shadow: var(--shadow);
+    padding: 1.5rem;
+}
+
+.table-wrapper {
+    overflow-x: auto;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 640px;
+}
+
+thead {
+    background-color: rgba(31, 60, 136, 0.08);
+}
+
+th,
+td {
+    text-align: left;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+tbody tr:hover {
+    background-color: rgba(31, 60, 136, 0.04);
+}
+
+.result-win {
+    color: #1c7c54;
+    font-weight: 600;
+}
+
+.result-loss {
+    color: #c81e1e;
+    font-weight: 600;
+}
+
+.result-draw {
+    color: #846358;
+    font-weight: 600;
+}
+
+footer {
+    background-color: #0b1f3a;
+    color: #cbd2d9;
+    text-align: center;
+    padding: 1.5rem 0;
+    margin-top: 2rem;
+    font-size: 0.95rem;
+}
+
+.hidden {
+    display: none;
+}
+
+@media (max-width: 600px) {
+    header {
+        padding: 2rem 0;
+    }
+
+    header h1 {
+        font-size: 1.6rem;
+    }
+
+    table {
+        min-width: unset;
+    }
+}


### PR DESCRIPTION
## Summary
- add a Python helper that downloads the upstream parquet dataset and exports matches.json
- document how to run the refresh script in the README so it can be scheduled easily

## Testing
- python -m compileall convert_parquet_to_json.py

------
https://chatgpt.com/codex/tasks/task_e_68c9b45aba10832993b362e401892c47